### PR TITLE
Add interactive installer for Raula ESLint config setup

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -38,6 +38,7 @@
         "tailwindcss": "4.2.4",
       },
       "devDependencies": {
+        "@types/node": "20.19.39",
         "tsup": "8.5.1",
         "typescript": "^5.9.3",
       },

--- a/packages/eslint-plugin-raula/README.md
+++ b/packages/eslint-plugin-raula/README.md
@@ -91,14 +91,6 @@ Run the linter from your app root:
 npm run lint
 ```
 
-For teams that use repository instructions, you can also inject only the managed reference block into `AGENTS.md`:
-
-```bash
-npx eslint-plugin-raula instruct
-```
-
-The generated block points contributors and coding agents to the installed rule reference before they edit styling, JSX class names, global CSS, or Next.js layout files.
-
 ## Usage
 
 You can also import the plugin directly and enable individual rules:
@@ -221,18 +213,12 @@ npx eslint-plugin-raula install
 The command:
 
 - Finds one ESLint flat config file in the current directory.
-- Shows the ESLint config diff and asks before applying it.
+- Asks before updating the ESLint config unless `--eslint` or `--no-eslint` is passed.
 - Adds both `eslint-plugin-raula/tailwind` and `eslint-plugin-raula/next-layout`.
-- Shows the `AGENTS.md` diff and asks before applying it.
+- Asks before updating `AGENTS.md` unless `--agents-md` or `--no-agents-md` is passed.
 
-Use `instruct` when you only want to inject the managed AGENTS reference block:
+For non-interactive usage:
 
 ```bash
-npx eslint-plugin-raula instruct
-```
-
-The command updates `AGENTS.md` in the current working directory with an idempotent block pointing to:
-
-```
-./node_modules/eslint-plugin-raula/REFERENCE.md
+npx eslint-plugin-raula install --eslint --agents-md
 ```

--- a/packages/eslint-plugin-raula/README.md
+++ b/packages/eslint-plugin-raula/README.md
@@ -17,7 +17,13 @@ bun add -d eslint eslint-plugin-raula
 
 ## Setup
 
-`eslint-plugin-raula` is designed for ESLint flat config. Create or update `eslint.config.mjs` in your project root, then import the presets you want.
+`eslint-plugin-raula` is designed for ESLint flat config. After installing the package, run the installer from your project root:
+
+```bash
+npx eslint-plugin-raula install
+```
+
+The installer looks for a single ESLint flat config file, shows the diff, asks for confirmation, and adds the Tailwind and Next.js layout presets. It can also update `AGENTS.md` with the managed Raula reference block. If multiple ESLint config files are found, the installer stops and asks you to update the intended file manually.
 
 ### Basic flat config
 
@@ -85,7 +91,7 @@ Run the linter from your app root:
 npm run lint
 ```
 
-For teams that use repository instructions, inject the managed reference block into `AGENTS.md` after installing the package:
+For teams that use repository instructions, you can also inject only the managed reference block into `AGENTS.md`:
 
 ```bash
 npx eslint-plugin-raula instruct
@@ -206,7 +212,20 @@ Read the package references before editing styling, `className` usage, global CS
 
 ## CLI
 
-Use the package CLI to inject the managed AGENTS reference block into the current repository:
+Use the package CLI to update the current repository after installing the package:
+
+```bash
+npx eslint-plugin-raula install
+```
+
+The command:
+
+- Finds one ESLint flat config file in the current directory.
+- Shows the ESLint config diff and asks before applying it.
+- Adds both `eslint-plugin-raula/tailwind` and `eslint-plugin-raula/next-layout`.
+- Shows the `AGENTS.md` diff and asks before applying it.
+
+Use `instruct` when you only want to inject the managed AGENTS reference block:
 
 ```bash
 npx eslint-plugin-raula instruct

--- a/packages/eslint-plugin-raula/bin/eslint-plugin-raula.js
+++ b/packages/eslint-plugin-raula/bin/eslint-plugin-raula.js
@@ -1,51 +1,5 @@
 #!/usr/bin/env node
 
-import fs from "node:fs/promises";
-import path from "node:path";
+import { runCli } from "../dist/cli.js";
 
-const START = "<!-- eslint-plugin-raula-instruct-start -->";
-const END = "<!-- eslint-plugin-raula-instruct-end -->";
-const AGENTS_FILE = "AGENTS.md";
-const REFERENCE_PATH = "./node_modules/eslint-plugin-raula/REFERENCE.md";
-
-const BLOCK = `${START}\n<!-- Managed by \`eslint-plugin-raula instruct\` -->\nBefore editing files that touch styling, JSX className usage, global CSS selectors, or Next.js layout files, read:\n\`${REFERENCE_PATH}\`\nThis block is supplemental and should complement, not override, local project instructions.\n${END}`;
-
-function escapeForRegExp(value) {
-	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-async function updateAgentsFile(cwd) {
-	const target = path.join(cwd, AGENTS_FILE);
-	const existing = await fs.readFile(target, "utf8").catch(() => "");
-	const blockRegex = new RegExp(
-		`${escapeForRegExp(START)}[\\s\\S]*?${escapeForRegExp(END)}\\s*`,
-		"g",
-	);
-
-	const next = blockRegex.test(existing)
-		? existing.replace(blockRegex, BLOCK)
-		: `${existing.trimEnd()}\n\n${BLOCK}\n`;
-
-	await fs.writeFile(target, next, "utf8");
-}
-
-function showUsage() {
-	console.log("Usage: eslint-plugin-raula instruct");
-	console.log(
-		"This command updates AGENTS.md in the current working directory with a managed Raula reference block.",
-	);
-}
-
-async function main() {
-	const command = process.argv[2];
-	if (command !== "instruct") {
-		showUsage();
-		process.exitCode = 1;
-		return;
-	}
-
-	await updateAgentsFile(process.cwd());
-	console.log("Updated AGENTS.md with eslint-plugin-raula reference block.");
-}
-
-await main();
+await runCli();

--- a/packages/eslint-plugin-raula/cli.ts
+++ b/packages/eslint-plugin-raula/cli.ts
@@ -1,0 +1,554 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { createInterface } from "node:readline/promises";
+import type { Readable, Writable } from "node:stream";
+
+const START = "<!-- eslint-plugin-raula-instruct-start -->";
+const END = "<!-- eslint-plugin-raula-instruct-end -->";
+const AGENTS_FILE = "AGENTS.md";
+const REFERENCE_PATH = "./node_modules/eslint-plugin-raula/REFERENCE.md";
+const ESLINT_CONFIG_FILES = [
+	"eslint.config.js",
+	"eslint.config.mjs",
+	"eslint.config.cjs",
+	"eslint.config.ts",
+	"eslint.config.mts",
+	"eslint.config.cts",
+];
+const RAULA_TAILWIND_IMPORT =
+	'import raulaTailwind from "eslint-plugin-raula/tailwind";';
+const RAULA_NEXT_LAYOUT_IMPORT =
+	'import raulaNextLayout from "eslint-plugin-raula/next-layout";';
+const RAULA_TAILWIND_SPREAD = "...raulaTailwind,";
+const RAULA_NEXT_LAYOUT_SPREAD = "...raulaNextLayout,";
+
+const BLOCK = `${START}\n<!-- Managed by \`eslint-plugin-raula instruct\` -->\nBefore editing files that touch styling, JSX className usage, global CSS selectors, or Next.js layout files, read:\n\`${REFERENCE_PATH}\`\nThis block is supplemental and should complement, not override, local project instructions.\n${END}`;
+
+const colors = {
+	green: "\x1b[32m",
+	yellow: "\x1b[33m",
+	red: "\x1b[31m",
+	cyan: "\x1b[36m",
+	dim: "\x1b[2m",
+	reset: "\x1b[0m",
+} as const;
+
+function color(value: string, code: string): string {
+	return `${code}${value}${colors.reset}`;
+}
+
+const log = {
+	info(message: string): void {
+		console.log(`${color("info", colors.cyan)} ${message}`);
+	},
+	success(message: string): void {
+		console.log(`${color("success", colors.green)} ${message}`);
+	},
+	warn(message: string): void {
+		console.warn(`${color("warn", colors.yellow)} ${message}`);
+	},
+};
+
+function escapeForRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+type AgentsFileUpdate = {
+	existing: string;
+	next: string;
+	target: string;
+};
+
+type CliIO = {
+	input: Readable;
+	output: Writable;
+};
+
+type PromptSession = {
+	ask(question: string): Promise<string>;
+	close(): void;
+};
+
+const defaultIO: CliIO = {
+	input: process.stdin,
+	output: process.stdout,
+};
+
+function createPromptSession(io: CliIO): PromptSession {
+	const rl = createInterface({
+		input: io.input,
+		crlfDelay: Number.POSITIVE_INFINITY,
+	});
+	const lines = rl[Symbol.asyncIterator]();
+
+	return {
+		async ask(question: string): Promise<string> {
+			io.output.write(question);
+			const answer = await lines.next();
+			return answer.done ? "" : answer.value;
+		},
+		close(): void {
+			rl.close();
+		},
+	};
+}
+
+export async function getAgentsFileUpdate(
+	cwd: string,
+): Promise<AgentsFileUpdate> {
+	const target = path.join(cwd, AGENTS_FILE);
+	const existing = await fs.readFile(target, "utf8").catch(() => "");
+	const blockRegex = new RegExp(
+		`${escapeForRegExp(START)}[\\s\\S]*?${escapeForRegExp(END)}\\s*`,
+		"g",
+	);
+
+	const next = blockRegex.test(existing)
+		? existing.replace(blockRegex, BLOCK)
+		: `${existing.trimEnd()}\n\n${BLOCK}\n`;
+
+	return { existing, next: `${next.trimEnd()}\n`, target };
+}
+
+export async function updateAgentsFile(cwd: string): Promise<void> {
+	const { next, target } = await getAgentsFileUpdate(cwd);
+	await fs.writeFile(target, next, "utf8");
+}
+
+export async function findEslintConfig(cwd: string): Promise<string[]> {
+	const found: string[] = [];
+	for (const file of ESLINT_CONFIG_FILES) {
+		const target = path.join(cwd, file);
+		const stat = await fs.stat(target).catch(() => undefined);
+		if (stat?.isFile()) {
+			found.push(target);
+		}
+	}
+	return found;
+}
+
+function findMatchingBracket(source: string, openIndex: number): number {
+	let depth = 0;
+	let quote: '"' | "'" | "`" | undefined;
+	let escaped = false;
+	let lineComment = false;
+	let blockComment = false;
+
+	for (let index = openIndex; index < source.length; index += 1) {
+		const current = source[index];
+		const next = source[index + 1];
+
+		if (lineComment) {
+			if (current === "\n") {
+				lineComment = false;
+			}
+			continue;
+		}
+
+		if (blockComment) {
+			if (current === "*" && next === "/") {
+				blockComment = false;
+				index += 1;
+			}
+			continue;
+		}
+
+		if (quote) {
+			if (escaped) {
+				escaped = false;
+			} else if (current === "\\") {
+				escaped = true;
+			} else if (current === quote) {
+				quote = undefined;
+			}
+			continue;
+		}
+
+		if (current === "/" && next === "/") {
+			lineComment = true;
+			index += 1;
+			continue;
+		}
+
+		if (current === "/" && next === "*") {
+			blockComment = true;
+			index += 1;
+			continue;
+		}
+
+		if (current === '"' || current === "'" || current === "`") {
+			quote = current;
+			continue;
+		}
+
+		if (current === "[") {
+			depth += 1;
+		} else if (current === "]") {
+			depth -= 1;
+			if (depth === 0) {
+				return index;
+			}
+		}
+	}
+
+	return -1;
+}
+
+function findConfigArray(source: string): number {
+	const defineConfigMatch = /defineConfig\s*\(\s*\[/.exec(source);
+	if (defineConfigMatch) {
+		return source.indexOf("[", defineConfigMatch.index);
+	}
+
+	const exportDefaultMatch = /export\s+default\s+\[/.exec(source);
+	if (exportDefaultMatch) {
+		return source.indexOf("[", exportDefaultMatch.index);
+	}
+
+	return -1;
+}
+
+function getLineIndent(source: string, index: number): string {
+	const lineStart = source.lastIndexOf("\n", index) + 1;
+	const match = /^[\t ]*/.exec(source.slice(lineStart));
+	return match?.[0] ?? "";
+}
+
+function getArrayItemIndent(source: string, openIndex: number): string {
+	const lineIndent = getLineIndent(source, openIndex);
+	const bodyStart = source.slice(openIndex + 1);
+	const firstItemIndent = /^\n([ \t]+)\S/m.exec(bodyStart);
+	return firstItemIndent?.[1] ?? `${lineIndent}\t`;
+}
+
+function insertImports(source: string): string {
+	const imports: string[] = [];
+	const next = source;
+
+	if (!/["']eslint-plugin-raula\/tailwind["']/.test(next)) {
+		imports.push(RAULA_TAILWIND_IMPORT);
+	}
+	if (!/["']eslint-plugin-raula\/next-layout["']/.test(next)) {
+		imports.push(RAULA_NEXT_LAYOUT_IMPORT);
+	}
+	if (imports.length === 0) {
+		return next;
+	}
+
+	const importMatches = [...next.matchAll(/^import[\s\S]*?;/gm)];
+	if (importMatches.length === 0) {
+		return `${imports.join("\n")}\n\n${next}`;
+	}
+
+	const lastImport = importMatches.at(-1);
+	if (!lastImport || lastImport.index === undefined) {
+		return `${imports.join("\n")}\n\n${next}`;
+	}
+
+	const insertAt = lastImport.index + lastImport[0].length;
+	return `${next.slice(0, insertAt)}\n${imports.join("\n")}${next.slice(insertAt)}`;
+}
+
+function insertPresetSpreads(source: string): string {
+	let next = source;
+	const openIndex = findConfigArray(next);
+	if (openIndex === -1) {
+		throw new Error(
+			"Could not find a supported flat config array. Please update your ESLint config manually.",
+		);
+	}
+
+	const closeIndex = findMatchingBracket(next, openIndex);
+	if (closeIndex === -1) {
+		throw new Error(
+			"Could not parse the ESLint config array. Please update your ESLint config manually.",
+		);
+	}
+
+	const body = next.slice(openIndex + 1, closeIndex);
+	const spreads: string[] = [];
+	if (!body.includes(RAULA_TAILWIND_SPREAD)) {
+		spreads.push(RAULA_TAILWIND_SPREAD);
+	}
+	if (!body.includes(RAULA_NEXT_LAYOUT_SPREAD)) {
+		spreads.push(RAULA_NEXT_LAYOUT_SPREAD);
+	}
+	if (spreads.length === 0) {
+		return next;
+	}
+
+	const itemIndent = getArrayItemIndent(next, openIndex);
+	const insertion = `\n${spreads.map((spread) => `${itemIndent}${spread}`).join("\n")}`;
+	next = `${next.slice(0, openIndex + 1)}${insertion}${next.slice(openIndex + 1)}`;
+	return next;
+}
+
+export function updateEslintConfig(source: string): string {
+	let next = insertImports(source);
+	next = insertPresetSpreads(next);
+	return next;
+}
+
+function createUnifiedDiff(
+	file: string,
+	before: string,
+	after: string,
+): string {
+	if (before === after) {
+		return color(`No changes for ${file}`, colors.dim);
+	}
+
+	const beforeLines = before.split("\n");
+	const afterLines = after.split("\n");
+	const table = Array.from({ length: beforeLines.length + 1 }, () =>
+		Array.from({ length: afterLines.length + 1 }, () => 0),
+	);
+
+	for (
+		let beforeIndex = beforeLines.length - 1;
+		beforeIndex >= 0;
+		beforeIndex -= 1
+	) {
+		for (
+			let afterIndex = afterLines.length - 1;
+			afterIndex >= 0;
+			afterIndex -= 1
+		) {
+			table[beforeIndex]![afterIndex] =
+				beforeLines[beforeIndex] === afterLines[afterIndex]
+					? table[beforeIndex + 1]![afterIndex + 1]! + 1
+					: Math.max(
+							table[beforeIndex + 1]![afterIndex]!,
+							table[beforeIndex]![afterIndex + 1]!,
+						);
+		}
+	}
+
+	const operations: { type: "same" | "added" | "removed"; value: string }[] =
+		[];
+	let beforeIndex = 0;
+	let afterIndex = 0;
+	while (beforeIndex < beforeLines.length || afterIndex < afterLines.length) {
+		if (beforeLines[beforeIndex] === afterLines[afterIndex]) {
+			operations.push({ type: "same", value: beforeLines[beforeIndex]! });
+			beforeIndex += 1;
+			afterIndex += 1;
+		} else if (
+			afterIndex < afterLines.length &&
+			(beforeIndex === beforeLines.length ||
+				table[beforeIndex]![afterIndex + 1]! >=
+					table[beforeIndex + 1]![afterIndex]!)
+		) {
+			operations.push({ type: "added", value: afterLines[afterIndex]! });
+			afterIndex += 1;
+		} else {
+			operations.push({ type: "removed", value: beforeLines[beforeIndex]! });
+			beforeIndex += 1;
+		}
+	}
+
+	const lines = [
+		color(`--- ${file}`, colors.dim),
+		color(`+++ ${file}`, colors.dim),
+	];
+	const changedIndexes = new Set<number>();
+	for (let index = 0; index < operations.length; index += 1) {
+		if (operations[index]!.type !== "same") {
+			for (
+				let contextIndex = Math.max(0, index - 3);
+				contextIndex <= Math.min(operations.length - 1, index + 3);
+				contextIndex += 1
+			) {
+				changedIndexes.add(contextIndex);
+			}
+		}
+	}
+
+	let skipped = false;
+	for (let index = 0; index < operations.length; index += 1) {
+		if (!changedIndexes.has(index)) {
+			skipped = true;
+			continue;
+		}
+		if (skipped) {
+			lines.push(color(" ...", colors.dim));
+			skipped = false;
+		}
+
+		const operation = operations[index]!;
+		if (operation.type === "same") {
+			lines.push(` ${operation.value}`);
+		} else if (operation.type === "added") {
+			lines.push(color(`+${operation.value}`, colors.green));
+		} else {
+			lines.push(color(`-${operation.value}`, colors.red));
+		}
+	}
+
+	return lines.join("\n");
+}
+
+async function confirm(
+	prompt: PromptSession,
+	question: string,
+	defaultValue = false,
+): Promise<boolean> {
+	const suffix = defaultValue ? "Y/n" : "y/N";
+	const answer = await prompt.ask(`${question} (${suffix}) `);
+	const normalized = answer.trim().toLowerCase();
+	if (normalized === "") {
+		return defaultValue;
+	}
+	return normalized === "y" || normalized === "yes";
+}
+
+export async function install(
+	cwd: string,
+	io: CliIO = defaultIO,
+): Promise<void> {
+	const configs = await findEslintConfig(cwd);
+	if (configs.length === 0) {
+		log.warn(
+			`No ESLint flat config found. Looked for: ${ESLINT_CONFIG_FILES.join(", ")}`,
+		);
+		return;
+	}
+	if (configs.length > 1) {
+		log.warn(
+			"Multiple ESLint config files found. Please keep one or update manually:",
+		);
+		for (const config of configs) {
+			console.warn(`  - ${path.relative(cwd, config)}`);
+		}
+		return;
+	}
+
+	const [configFile] = configs;
+	if (!configFile) {
+		return;
+	}
+
+	const configBefore = await fs.readFile(configFile, "utf8");
+	let configAfter: string;
+	try {
+		configAfter = updateEslintConfig(configBefore);
+	} catch (error) {
+		if (error instanceof Error) {
+			log.warn(error.message);
+		}
+		return;
+	}
+
+	if (configBefore === configAfter) {
+		log.info(`${path.basename(configFile)} already includes Raula presets.`);
+	} else {
+		const prompt = createPromptSession(io);
+		console.log(
+			createUnifiedDiff(
+				path.relative(cwd, configFile),
+				configBefore,
+				configAfter,
+			),
+		);
+
+		try {
+			const shouldUpdateConfig = await confirm(
+				prompt,
+				"Apply ESLint config changes?",
+			);
+			if (shouldUpdateConfig) {
+				await fs.writeFile(configFile, configAfter, "utf8");
+				log.success(`Updated ${path.relative(cwd, configFile)}.`);
+			} else {
+				log.info("Skipped ESLint config update.");
+			}
+
+			const agentsUpdate = await getAgentsFileUpdate(cwd);
+			if (agentsUpdate.existing === agentsUpdate.next) {
+				log.info("AGENTS.md already includes the Raula reference block.");
+				return;
+			}
+
+			console.log(
+				createUnifiedDiff(
+					path.relative(cwd, agentsUpdate.target),
+					agentsUpdate.existing,
+					agentsUpdate.next,
+				),
+			);
+			const shouldUpdateAgents = await confirm(
+				prompt,
+				"Update AGENTS.md with Raula instructions?",
+			);
+			if (shouldUpdateAgents) {
+				await fs.writeFile(agentsUpdate.target, agentsUpdate.next, "utf8");
+				log.success("Updated AGENTS.md.");
+			} else {
+				log.info("Skipped AGENTS.md update.");
+			}
+		} finally {
+			prompt.close();
+		}
+		return;
+	}
+
+	const agentsUpdate = await getAgentsFileUpdate(cwd);
+	if (agentsUpdate.existing === agentsUpdate.next) {
+		log.info("AGENTS.md already includes the Raula reference block.");
+		return;
+	}
+
+	const prompt = createPromptSession(io);
+	try {
+		console.log(
+			createUnifiedDiff(
+				path.relative(cwd, agentsUpdate.target),
+				agentsUpdate.existing,
+				agentsUpdate.next,
+			),
+		);
+		const shouldUpdateAgents = await confirm(
+			prompt,
+			"Update AGENTS.md with Raula instructions?",
+		);
+		if (shouldUpdateAgents) {
+			await fs.writeFile(agentsUpdate.target, agentsUpdate.next, "utf8");
+			log.success("Updated AGENTS.md.");
+		} else {
+			log.info("Skipped AGENTS.md update.");
+		}
+	} finally {
+		prompt.close();
+	}
+}
+
+function showUsage(): void {
+	console.log("Usage: eslint-plugin-raula <command>");
+	console.log("");
+	console.log("Commands:");
+	console.log("  install   Update ESLint flat config and optionally AGENTS.md");
+	console.log(
+		"  instruct  Update AGENTS.md with a managed Raula reference block",
+	);
+}
+
+export async function runCli(
+	argv = process.argv,
+	cwd = process.cwd(),
+	io: CliIO = defaultIO,
+): Promise<void> {
+	const command = argv[2];
+	if (command === "install") {
+		await install(cwd, io);
+		return;
+	}
+
+	if (command === "instruct") {
+		await updateAgentsFile(cwd);
+		log.success("Updated AGENTS.md with eslint-plugin-raula reference block.");
+		return;
+	}
+
+	showUsage();
+	process.exitCode = 1;
+}

--- a/packages/eslint-plugin-raula/cli.ts
+++ b/packages/eslint-plugin-raula/cli.ts
@@ -1,10 +1,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { emitKeypressEvents } from "node:readline";
 import { createInterface } from "node:readline/promises";
-import type { Readable, Writable } from "node:stream";
 
-const START = "<!-- eslint-plugin-raula-instruct-start -->";
-const END = "<!-- eslint-plugin-raula-instruct-end -->";
+const START = "<!-- eslint-plugin-raula-start -->";
+const END = "<!-- eslint-plugin-raula-end -->";
 const AGENTS_FILE = "AGENTS.md";
 const REFERENCE_PATH = "./node_modules/eslint-plugin-raula/REFERENCE.md";
 const ESLINT_CONFIG_FILES = [
@@ -22,32 +22,17 @@ const RAULA_NEXT_LAYOUT_IMPORT =
 const RAULA_TAILWIND_SPREAD = "...raulaTailwind,";
 const RAULA_NEXT_LAYOUT_SPREAD = "...raulaNextLayout,";
 
-const BLOCK = `${START}\n<!-- Managed by \`eslint-plugin-raula instruct\` -->\nBefore editing files that touch styling, JSX className usage, global CSS selectors, or Next.js layout files, read:\n\`${REFERENCE_PATH}\`\nThis block is supplemental and should complement, not override, local project instructions.\n${END}`;
+const BLOCK = `${START}\n<!-- Managed by \`eslint-plugin-raula install\` -->\nBefore editing files that touch styling, JSX className usage, global CSS selectors, or Next.js layout files, read:\n\`${REFERENCE_PATH}\`\nThis block is supplemental and should complement, not override, local project instructions.\n${END}`;
+const CLEAR_LINE = "\r\x1b[2K";
+const HIDE_CURSOR = "\x1b[?25l";
+const SHOW_CURSOR = "\x1b[?25h";
 
-const colors = {
-	green: "\x1b[32m",
-	yellow: "\x1b[33m",
-	red: "\x1b[31m",
-	cyan: "\x1b[36m",
-	dim: "\x1b[2m",
-	reset: "\x1b[0m",
+const color = {
+	cyan: (value: string) => `\x1b[36m${value}\x1b[0m`,
+	green: (value: string) => `\x1b[32m${value}\x1b[0m`,
+	yellow: (value: string) => `\x1b[33m${value}\x1b[0m`,
+	underline: (value: string) => `\x1b[4m${value}\x1b[0m`,
 } as const;
-
-function color(value: string, code: string): string {
-	return `${code}${value}${colors.reset}`;
-}
-
-const log = {
-	info(message: string): void {
-		console.log(`${color("info", colors.cyan)} ${message}`);
-	},
-	success(message: string): void {
-		console.log(`${color("success", colors.green)} ${message}`);
-	},
-	warn(message: string): void {
-		console.warn(`${color("warn", colors.yellow)} ${message}`);
-	},
-};
 
 function escapeForRegExp(value: string): string {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -59,39 +44,181 @@ type AgentsFileUpdate = {
 	target: string;
 };
 
-type CliIO = {
-	input: Readable;
-	output: Writable;
+type CliUi = {
+	intro(message: string): void;
+	outro(message: string): void;
+	info(message: string): void;
+	warn(message: string): void;
+	error(message: string): void;
+	cancel(message: string): void;
+	progress(message: string): void;
+	confirm(message: string): Promise<boolean | "cancel">;
+	close?(): void;
 };
 
-type PromptSession = {
-	ask(question: string): Promise<string>;
-	close(): void;
-};
-
-const defaultIO: CliIO = {
-	input: process.stdin,
-	output: process.stdout,
-};
-
-function createPromptSession(io: CliIO): PromptSession {
+function createConsoleUi(): CliUi {
 	const rl = createInterface({
-		input: io.input,
+		input: process.stdin,
 		crlfDelay: Number.POSITIVE_INFINITY,
 	});
 	const lines = rl[Symbol.asyncIterator]();
 
 	return {
-		async ask(question: string): Promise<string> {
-			io.output.write(question);
-			const answer = await lines.next();
-			return answer.done ? "" : answer.value;
+		intro(message: string): void {
+			console.log(message);
+		},
+		outro(message: string): void {
+			console.log(`\n${message}`);
+		},
+		info(message: string): void {
+			console.log(`${color.green("✔")} ${message}`);
+		},
+		warn(message: string): void {
+			console.warn(`! ${message}`);
+		},
+		error(message: string): void {
+			console.error(`! ${message}`);
+		},
+		cancel(message: string): void {
+			console.log(`× ${message}`);
+		},
+		progress(message: string): void {
+			console.log(`\n${message}`);
+		},
+		async confirm(message: string): Promise<boolean | "cancel"> {
+			if (
+				process.stdin.isTTY &&
+				process.stdout.isTTY &&
+				typeof process.stdin.setRawMode === "function"
+			) {
+				return confirmWithKeypress(message);
+			}
+
+			process.stdout.write(`→ ${message} > Yes / No `);
+			const line = await lines.next();
+			const answer = line.done ? "" : line.value;
+			const normalized = answer.trim().toLowerCase();
+			const result =
+				normalized === "" || normalized === "y" || normalized === "yes";
+			if (process.stdout.isTTY) {
+				process.stdout.write("\x1b[1A\x1b[2K");
+			} else if (!process.stdin.isTTY) {
+				process.stdout.write("\n");
+			}
+			console.log(`${color.green("✔")} ${message} > ${formatChoices(result)}`);
+			return result;
 		},
 		close(): void {
 			rl.close();
 		},
 	};
 }
+
+function formatChoice(label: "No" | "Yes", selected: boolean): string {
+	if (!selected) {
+		return label;
+	}
+	return color.underline(color.cyan(label));
+}
+
+function formatChoices(selected: boolean): string {
+	const no = formatChoice("No", !selected);
+	const yes = formatChoice("Yes", selected);
+	return `${no} / ${yes}`;
+}
+
+function formatEmphasis(value: string): string {
+	return color.yellow(value);
+}
+
+async function confirmWithKeypress(
+	message: string,
+	defaultValue = true,
+): Promise<boolean | "cancel"> {
+	let selected = defaultValue;
+	const render = () => {
+		process.stdout.write(
+			`${CLEAR_LINE}${color.cyan("?")} ${message} ${color.cyan("›")} ${formatChoices(selected)}`,
+		);
+	};
+	const renderDone = () => {
+		process.stdout.write(
+			`${CLEAR_LINE}${color.green("✔")} ${message} ${color.cyan("›")} ${formatChoices(selected)}\n`,
+		);
+	};
+
+	emitKeypressEvents(process.stdin);
+	process.stdin.setRawMode(true);
+	process.stdin.resume();
+	process.stdout.write(HIDE_CURSOR);
+	render();
+
+	return new Promise((resolve) => {
+		const cleanup = () => {
+			process.stdin.off("keypress", onKeypress);
+			process.stdin.setRawMode(false);
+			process.stdout.write(SHOW_CURSOR);
+			rlResumeIfNeeded();
+		};
+		const finish = (value: boolean | "cancel") => {
+			cleanup();
+			if (value === "cancel") {
+				process.stdout.write(`${CLEAR_LINE}`);
+			} else {
+				renderDone();
+			}
+			resolve(value);
+		};
+		const onKeypress = (
+			_chunk: string,
+			key: { name?: string; ctrl?: boolean },
+		) => {
+			if (key.ctrl && key.name === "c") {
+				finish("cancel");
+				return;
+			}
+			if (key.name === "left" || key.name === "right") {
+				selected = !selected;
+				render();
+				return;
+			}
+			if (key.name === "tab") {
+				selected = !selected;
+				render();
+				return;
+			}
+			if (key.name === "return" || key.name === "enter") {
+				finish(selected);
+			}
+		};
+
+		process.stdin.on("keypress", onKeypress);
+	});
+}
+
+function rlResumeIfNeeded(): void {
+	if (!process.stdin.isPaused()) {
+		return;
+	}
+	process.stdin.resume();
+}
+
+type InstallOptionValue = boolean | undefined;
+
+type InstallOptions = {
+	eslint: InstallOptionValue;
+	agentsMd: InstallOptionValue;
+};
+
+type InstallInput = {
+	options?: InstallOptions;
+	ui?: CliUi;
+};
+
+const defaultInstallOptions: InstallOptions = {
+	eslint: undefined,
+	agentsMd: undefined,
+};
 
 export async function getAgentsFileUpdate(
 	cwd: string,
@@ -108,11 +235,6 @@ export async function getAgentsFileUpdate(
 		: `${existing.trimEnd()}\n\n${BLOCK}\n`;
 
 	return { existing, next: `${next.trimEnd()}\n`, target };
-}
-
-export async function updateAgentsFile(cwd: string): Promise<void> {
-	const { next, target } = await getAgentsFileUpdate(cwd);
-	await fs.writeFile(target, next, "utf8");
 }
 
 export async function findEslintConfig(cwd: string): Promise<string[]> {
@@ -214,11 +336,52 @@ function getLineIndent(source: string, index: number): string {
 	return match?.[0] ?? "";
 }
 
-function getArrayItemIndent(source: string, openIndex: number): string {
+function detectIndentUnit(source: string): string {
+	const indents = source.match(/^[ \t]+(?=\S)/gm) ?? [];
+	let tabIndentedLines = 0;
+	const spaceIndentLengths: number[] = [];
+
+	for (const indent of indents) {
+		if (indent.includes("\t")) {
+			tabIndentedLines += 1;
+			continue;
+		}
+		spaceIndentLengths.push(indent.length);
+	}
+
+	if (tabIndentedLines > 0) {
+		return "\t";
+	}
+
+	if (spaceIndentLengths.length === 0) {
+		return "  ";
+	}
+
+	const scoreFor = (size: number): number =>
+		spaceIndentLengths.filter((length) => length % size === 0).length;
+	const score2 = scoreFor(2);
+	const score4 = scoreFor(4);
+
+	if (score4 > 0 && score4 >= score2) {
+		return "    ";
+	}
+	if (score2 > 0) {
+		return "  ";
+	}
+
+	return "  ";
+}
+
+function getArrayItemIndent(
+	source: string,
+	openIndex: number,
+	closeIndex: number,
+	indentUnit: string,
+): string {
 	const lineIndent = getLineIndent(source, openIndex);
-	const bodyStart = source.slice(openIndex + 1);
-	const firstItemIndent = /^\n([ \t]+)\S/m.exec(bodyStart);
-	return firstItemIndent?.[1] ?? `${lineIndent}\t`;
+	const arrayBody = source.slice(openIndex + 1, closeIndex);
+	const firstItemIndent = /^\n([ \t]+)\S/m.exec(arrayBody);
+	return firstItemIndent?.[1] ?? `${lineIndent}${indentUnit}`;
 }
 
 function insertImports(source: string): string {
@@ -277,7 +440,13 @@ function insertPresetSpreads(source: string): string {
 		return next;
 	}
 
-	const itemIndent = getArrayItemIndent(next, openIndex);
+	const indentUnit = detectIndentUnit(next);
+	const itemIndent = getArrayItemIndent(
+		next,
+		openIndex,
+		closeIndex,
+		indentUnit,
+	);
 	const insertion = `\n${spreads.map((spread) => `${itemIndent}${spread}`).join("\n")}`;
 	next = `${next.slice(0, openIndex + 1)}${insertion}${next.slice(openIndex + 1)}`;
 	return next;
@@ -289,264 +458,214 @@ export function updateEslintConfig(source: string): string {
 	return next;
 }
 
-function createUnifiedDiff(
-	file: string,
-	before: string,
-	after: string,
-): string {
-	if (before === after) {
-		return color(`No changes for ${file}`, colors.dim);
+function formatUpdatedTargets(targets: string[]): string {
+	if (targets.length === 0) {
+		return "";
 	}
-
-	const beforeLines = before.split("\n");
-	const afterLines = after.split("\n");
-	const table = Array.from({ length: beforeLines.length + 1 }, () =>
-		Array.from({ length: afterLines.length + 1 }, () => 0),
-	);
-
-	for (
-		let beforeIndex = beforeLines.length - 1;
-		beforeIndex >= 0;
-		beforeIndex -= 1
-	) {
-		for (
-			let afterIndex = afterLines.length - 1;
-			afterIndex >= 0;
-			afterIndex -= 1
-		) {
-			table[beforeIndex]![afterIndex] =
-				beforeLines[beforeIndex] === afterLines[afterIndex]
-					? table[beforeIndex + 1]![afterIndex + 1]! + 1
-					: Math.max(
-							table[beforeIndex + 1]![afterIndex]!,
-							table[beforeIndex]![afterIndex + 1]!,
-						);
-		}
+	if (targets.length === 1) {
+		return targets[0]!;
 	}
-
-	const operations: { type: "same" | "added" | "removed"; value: string }[] =
-		[];
-	let beforeIndex = 0;
-	let afterIndex = 0;
-	while (beforeIndex < beforeLines.length || afterIndex < afterLines.length) {
-		if (beforeLines[beforeIndex] === afterLines[afterIndex]) {
-			operations.push({ type: "same", value: beforeLines[beforeIndex]! });
-			beforeIndex += 1;
-			afterIndex += 1;
-		} else if (
-			afterIndex < afterLines.length &&
-			(beforeIndex === beforeLines.length ||
-				table[beforeIndex]![afterIndex + 1]! >=
-					table[beforeIndex + 1]![afterIndex]!)
-		) {
-			operations.push({ type: "added", value: afterLines[afterIndex]! });
-			afterIndex += 1;
-		} else {
-			operations.push({ type: "removed", value: beforeLines[beforeIndex]! });
-			beforeIndex += 1;
-		}
-	}
-
-	const lines = [
-		color(`--- ${file}`, colors.dim),
-		color(`+++ ${file}`, colors.dim),
-	];
-	const changedIndexes = new Set<number>();
-	for (let index = 0; index < operations.length; index += 1) {
-		if (operations[index]!.type !== "same") {
-			for (
-				let contextIndex = Math.max(0, index - 3);
-				contextIndex <= Math.min(operations.length - 1, index + 3);
-				contextIndex += 1
-			) {
-				changedIndexes.add(contextIndex);
-			}
-		}
-	}
-
-	let skipped = false;
-	for (let index = 0; index < operations.length; index += 1) {
-		if (!changedIndexes.has(index)) {
-			skipped = true;
-			continue;
-		}
-		if (skipped) {
-			lines.push(color(" ...", colors.dim));
-			skipped = false;
-		}
-
-		const operation = operations[index]!;
-		if (operation.type === "same") {
-			lines.push(` ${operation.value}`);
-		} else if (operation.type === "added") {
-			lines.push(color(`+${operation.value}`, colors.green));
-		} else {
-			lines.push(color(`-${operation.value}`, colors.red));
-		}
-	}
-
-	return lines.join("\n");
+	return `${targets.slice(0, -1).join(", ")} and ${targets.at(-1)}`;
 }
 
-async function confirm(
-	prompt: PromptSession,
-	question: string,
-	defaultValue = false,
-): Promise<boolean> {
-	const suffix = defaultValue ? "Y/n" : "y/N";
-	const answer = await prompt.ask(`${question} (${suffix}) `);
-	const normalized = answer.trim().toLowerCase();
-	if (normalized === "") {
-		return defaultValue;
+function getPendingUpdate(existing: string, next: string): boolean {
+	return existing !== next;
+}
+
+function parseInstallOptions(args: string[]): InstallOptions {
+	const options: InstallOptions = { ...defaultInstallOptions };
+
+	for (const arg of args) {
+		if (arg === "--eslint") {
+			if (options.eslint === false) {
+				throw new Error("Conflicting options: --eslint and --no-eslint");
+			}
+			options.eslint = true;
+			continue;
+		}
+		if (arg === "--no-eslint") {
+			if (options.eslint === true) {
+				throw new Error("Conflicting options: --eslint and --no-eslint");
+			}
+			options.eslint = false;
+			continue;
+		}
+		if (arg === "--agents-md") {
+			if (options.agentsMd === false) {
+				throw new Error("Conflicting options: --agents-md and --no-agents-md");
+			}
+			options.agentsMd = true;
+			continue;
+		}
+		if (arg === "--no-agents-md") {
+			if (options.agentsMd === true) {
+				throw new Error("Conflicting options: --agents-md and --no-agents-md");
+			}
+			options.agentsMd = false;
+			continue;
+		}
+		throw new Error(`Unknown option: ${arg}`);
 	}
-	return normalized === "y" || normalized === "yes";
+
+	return options;
 }
 
 export async function install(
 	cwd: string,
-	io: CliIO = defaultIO,
+	input: InstallInput = {},
 ): Promise<void> {
-	const configs = await findEslintConfig(cwd);
-	if (configs.length === 0) {
-		log.warn(
-			`No ESLint flat config found. Looked for: ${ESLINT_CONFIG_FILES.join(", ")}`,
-		);
-		return;
-	}
-	if (configs.length > 1) {
-		log.warn(
-			"Multiple ESLint config files found. Please keep one or update manually:",
-		);
-		for (const config of configs) {
-			console.warn(`  - ${path.relative(cwd, config)}`);
-		}
-		return;
-	}
-
-	const [configFile] = configs;
-	if (!configFile) {
-		return;
-	}
-
-	const configBefore = await fs.readFile(configFile, "utf8");
-	let configAfter: string;
+	const ui = input.ui ?? createConsoleUi();
+	const options = input.options ?? defaultInstallOptions;
 	try {
-		configAfter = updateEslintConfig(configBefore);
-	} catch (error) {
-		if (error instanceof Error) {
-			log.warn(error.message);
+		ui.intro("Installing eslint-plugin-raula...");
+
+		const configs = await findEslintConfig(cwd);
+		if (configs.length === 0) {
+			ui.warn(
+				`No ESLint flat config found. Looked for: ${ESLINT_CONFIG_FILES.join(", ")}`,
+			);
+			ui.outro("No changes applied.");
+			return;
 		}
-		return;
-	}
+		if (configs.length > 1) {
+			ui.warn(
+				"Multiple ESLint config files found. Please keep one or update manually:",
+			);
+			for (const config of configs) {
+				ui.warn(`- ${path.relative(cwd, config)}`);
+			}
+			ui.outro("No changes applied.");
+			return;
+		}
 
-	if (configBefore === configAfter) {
-		log.info(`${path.basename(configFile)} already includes Raula presets.`);
-	} else {
-		const prompt = createPromptSession(io);
-		console.log(
-			createUnifiedDiff(
-				path.relative(cwd, configFile),
-				configBefore,
-				configAfter,
-			),
-		);
+		const [configFile] = configs;
+		if (!configFile) {
+			return;
+		}
 
+		const configBefore = await fs.readFile(configFile, "utf8");
+		let configAfter: string;
 		try {
-			const shouldUpdateConfig = await confirm(
-				prompt,
-				"Apply ESLint config changes?",
-			);
-			if (shouldUpdateConfig) {
-				await fs.writeFile(configFile, configAfter, "utf8");
-				log.success(`Updated ${path.relative(cwd, configFile)}.`);
-			} else {
-				log.info("Skipped ESLint config update.");
+			configAfter = updateEslintConfig(configBefore);
+		} catch (error) {
+			if (error instanceof Error) {
+				ui.warn(error.message);
 			}
-
-			const agentsUpdate = await getAgentsFileUpdate(cwd);
-			if (agentsUpdate.existing === agentsUpdate.next) {
-				log.info("AGENTS.md already includes the Raula reference block.");
-				return;
-			}
-
-			console.log(
-				createUnifiedDiff(
-					path.relative(cwd, agentsUpdate.target),
-					agentsUpdate.existing,
-					agentsUpdate.next,
-				),
-			);
-			const shouldUpdateAgents = await confirm(
-				prompt,
-				"Update AGENTS.md with Raula instructions?",
-			);
-			if (shouldUpdateAgents) {
-				await fs.writeFile(agentsUpdate.target, agentsUpdate.next, "utf8");
-				log.success("Updated AGENTS.md.");
-			} else {
-				log.info("Skipped AGENTS.md update.");
-			}
-		} finally {
-			prompt.close();
+			ui.outro("No changes applied.");
+			return;
 		}
-		return;
-	}
 
-	const agentsUpdate = await getAgentsFileUpdate(cwd);
-	if (agentsUpdate.existing === agentsUpdate.next) {
-		log.info("AGENTS.md already includes the Raula reference block.");
-		return;
-	}
+		ui.info(`Found ESLint config: ${path.relative(cwd, configFile)}`);
 
-	const prompt = createPromptSession(io);
-	try {
-		console.log(
-			createUnifiedDiff(
-				path.relative(cwd, agentsUpdate.target),
-				agentsUpdate.existing,
-				agentsUpdate.next,
-			),
+		const configPending = getPendingUpdate(configBefore, configAfter);
+		if (!configPending) {
+			ui.info(`${path.basename(configFile)} already includes Raula presets.`);
+		}
+
+		const agentsUpdate = await getAgentsFileUpdate(cwd);
+		const agentsPending = getPendingUpdate(
+			agentsUpdate.existing,
+			agentsUpdate.next,
 		);
-		const shouldUpdateAgents = await confirm(
-			prompt,
-			"Update AGENTS.md with Raula instructions?",
-		);
+		if (!agentsPending) {
+			ui.info("AGENTS.md already includes the Raula reference block.");
+		}
+
+		if (!configPending && !agentsPending) {
+			ui.outro("Everything is already up to date.");
+			return;
+		}
+
+		let shouldUpdateConfig = false;
+		let shouldUpdateAgents = false;
+
+		if (configPending) {
+			if (options.eslint !== undefined) {
+				shouldUpdateConfig = options.eslint;
+			} else {
+				const result = await ui.confirm(
+					`Would you like to update ${formatEmphasis(path.relative(cwd, configFile))} with Raula presets?`,
+				);
+				if (result === "cancel") {
+					ui.cancel("Cancelled. No changes applied.");
+					ui.outro("No changes applied.");
+					return;
+				}
+				shouldUpdateConfig = result;
+			}
+		}
+
+		if (agentsPending) {
+			if (options.agentsMd !== undefined) {
+				shouldUpdateAgents = options.agentsMd;
+			} else {
+				const result = await ui.confirm(
+					`Would you like to update ${formatEmphasis(AGENTS_FILE)} with Raula instructions?`,
+				);
+				if (result === "cancel") {
+					ui.cancel("Cancelled. No changes applied.");
+					ui.outro("No changes applied.");
+					return;
+				}
+				shouldUpdateAgents = result;
+			}
+		}
+
+		const updatedTargets: string[] = [];
+		if (shouldUpdateConfig || shouldUpdateAgents) {
+			ui.progress("Updating...");
+		}
+		if (shouldUpdateConfig) {
+			await fs.writeFile(configFile, configAfter, "utf8");
+			updatedTargets.push("ESLint config");
+		}
 		if (shouldUpdateAgents) {
 			await fs.writeFile(agentsUpdate.target, agentsUpdate.next, "utf8");
-			log.success("Updated AGENTS.md.");
+			updatedTargets.push("AGENTS.md");
+		}
+
+		if (updatedTargets.length > 0) {
+			ui.outro(
+				`${color.green("Success!")} Updated ${formatUpdatedTargets(updatedTargets)}.`,
+			);
 		} else {
-			log.info("Skipped AGENTS.md update.");
+			ui.outro("No changes applied.");
 		}
 	} finally {
-		prompt.close();
+		ui.close?.();
 	}
 }
 
 function showUsage(): void {
-	console.log("Usage: eslint-plugin-raula <command>");
+	console.log("Usage: eslint-plugin-raula install [options]");
 	console.log("");
-	console.log("Commands:");
-	console.log("  install   Update ESLint flat config and optionally AGENTS.md");
-	console.log(
-		"  instruct  Update AGENTS.md with a managed Raula reference block",
-	);
+	console.log("Options:");
+	console.log("  --eslint       Update ESLint config without prompting");
+	console.log("  --no-eslint    Skip ESLint config update without prompting");
+	console.log("  --agents-md    Update AGENTS.md without prompting");
+	console.log("  --no-agents-md Skip AGENTS.md update without prompting");
 }
 
 export async function runCli(
 	argv = process.argv,
 	cwd = process.cwd(),
-	io: CliIO = defaultIO,
+	ui?: CliUi,
 ): Promise<void> {
 	const command = argv[2];
 	if (command === "install") {
-		await install(cwd, io);
-		return;
-	}
-
-	if (command === "instruct") {
-		await updateAgentsFile(cwd);
-		log.success("Updated AGENTS.md with eslint-plugin-raula reference block.");
-		return;
+		const installUi = ui ?? createConsoleUi();
+		try {
+			const options = parseInstallOptions(argv.slice(3));
+			await install(cwd, { options, ui: installUi });
+			return;
+		} catch (error) {
+			const message =
+				error instanceof Error ? error.message : "Invalid install options.";
+			installUi.error(message);
+			installUi.close?.();
+			process.exitCode = 1;
+			return;
+		}
 	}
 
 	showUsage();

--- a/packages/eslint-plugin-raula/package.json
+++ b/packages/eslint-plugin-raula/package.json
@@ -65,6 +65,7 @@
 		"tailwindcss": "4.2.4"
 	},
 	"devDependencies": {
+		"@types/node": "20.19.39",
 		"tsup": "8.5.1",
 		"typescript": "^5.9.3"
 	}

--- a/packages/eslint-plugin-raula/tests/cli.test.ts
+++ b/packages/eslint-plugin-raula/tests/cli.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Readable, Writable } from "node:stream";
+
+import {
+	findEslintConfig,
+	getAgentsFileUpdate,
+	install,
+	updateEslintConfig,
+} from "../cli";
+
+const createNextConfig = `import { defineConfig, globalIgnores } from "eslint/config";
+import nextVitals from "eslint-config-next/core-web-vitals";
+import nextTs from "eslint-config-next/typescript";
+
+const eslintConfig = defineConfig([
+  ...nextVitals,
+  ...nextTs,
+  // Override default ignores of eslint-config-next.
+  globalIgnores([
+    // Default ignores of eslint-config-next:
+    ".next/**",
+    "out/**",
+    "build/**",
+    "next-env.d.ts",
+  ]),
+]);
+
+export default eslintConfig;
+`;
+
+function createWritableBuffer() {
+	let output = "";
+	return {
+		stream: new Writable({
+			write(chunk, _encoding, callback) {
+				output += chunk.toString();
+				callback();
+			},
+		}),
+		get output() {
+			return output;
+		},
+	};
+}
+
+describe("eslint-plugin-raula CLI", () => {
+	test("adds Raula presets to create-next flat config", () => {
+		const updated = updateEslintConfig(createNextConfig);
+
+		expect(
+			updated,
+		).toBe(`import { defineConfig, globalIgnores } from "eslint/config";
+import nextVitals from "eslint-config-next/core-web-vitals";
+import nextTs from "eslint-config-next/typescript";
+import raulaTailwind from "eslint-plugin-raula/tailwind";
+import raulaNextLayout from "eslint-plugin-raula/next-layout";
+
+const eslintConfig = defineConfig([
+  ...raulaTailwind,
+  ...raulaNextLayout,
+  ...nextVitals,
+  ...nextTs,
+  // Override default ignores of eslint-config-next.
+  globalIgnores([
+    // Default ignores of eslint-config-next:
+    ".next/**",
+    "out/**",
+    "build/**",
+    "next-env.d.ts",
+  ]),
+]);
+
+export default eslintConfig;
+`);
+		expect(updateEslintConfig(updated)).toBe(updated);
+	});
+
+	test("adds Raula presets to export default array flat config", () => {
+		const source = `export default [
+\t{
+\t\trules: {},
+\t},
+];
+`;
+
+		const updated = updateEslintConfig(source);
+
+		expect(updated).toContain(
+			'import raulaTailwind from "eslint-plugin-raula/tailwind";',
+		);
+		expect(updated).toContain(
+			'import raulaNextLayout from "eslint-plugin-raula/next-layout";',
+		);
+		expect(updated).toContain("\t...raulaTailwind,\n\t...raulaNextLayout,");
+	});
+
+	test("throws for unsupported config shapes", () => {
+		expect(() =>
+			updateEslintConfig("export default function config() { return []; }"),
+		).toThrow("Could not find a supported flat config array");
+	});
+
+	test("finds every root ESLint config candidate", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "raula-cli-"));
+		await writeFile(join(cwd, "eslint.config.mjs"), "export default [];");
+		await writeFile(join(cwd, "eslint.config.js"), "export default [];");
+
+		const configs = await findEslintConfig(cwd);
+
+		expect(configs.map((config) => config.split("/").at(-1))).toEqual([
+			"eslint.config.js",
+			"eslint.config.mjs",
+		]);
+	});
+
+	test("keeps managed AGENTS block idempotent", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "raula-cli-"));
+		await writeFile(
+			join(cwd, "AGENTS.md"),
+			[
+				"# Local instructions",
+				"",
+				"<!-- eslint-plugin-raula-instruct-start -->",
+				"<!-- Managed by `eslint-plugin-raula instruct` -->",
+				"Before editing files that touch styling, JSX className usage, global CSS selectors, or Next.js layout files, read:",
+				"`./node_modules/eslint-plugin-raula/REFERENCE.md`",
+				"This block is supplemental and should complement, not override, local project instructions.",
+				"<!-- eslint-plugin-raula-instruct-end -->",
+				"",
+			].join("\n"),
+		);
+
+		const update = await getAgentsFileUpdate(cwd);
+
+		expect(update.next).toBe(update.existing);
+	});
+
+	test("accepts piped yes answers for ESLint config and AGENTS prompts", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "raula-cli-"));
+		await writeFile(join(cwd, "eslint.config.mjs"), createNextConfig);
+		await writeFile(join(cwd, "AGENTS.md"), "# Local instructions\n");
+		const output = createWritableBuffer();
+
+		await install(cwd, {
+			input: Readable.from(["y\ny\n"]),
+			output: output.stream,
+		});
+
+		const eslintConfig = await readFile(join(cwd, "eslint.config.mjs"), "utf8");
+		const agents = await readFile(join(cwd, "AGENTS.md"), "utf8");
+
+		expect(eslintConfig).toContain(
+			'import raulaTailwind from "eslint-plugin-raula/tailwind";',
+		);
+		expect(eslintConfig).toContain(
+			'import raulaNextLayout from "eslint-plugin-raula/next-layout";',
+		);
+		expect(eslintConfig).toContain(
+			"  ...raulaTailwind,\n  ...raulaNextLayout,\n  ...nextVitals,",
+		);
+		expect(agents).toContain("<!-- eslint-plugin-raula-instruct-start -->");
+		expect(output.output).toContain("Apply ESLint config changes?");
+		expect(output.output).toContain(
+			"Update AGENTS.md with Raula instructions?",
+		);
+	});
+});

--- a/packages/eslint-plugin-raula/tests/cli.test.ts
+++ b/packages/eslint-plugin-raula/tests/cli.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, test } from "bun:test";
 import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Readable, Writable } from "node:stream";
 
 import {
 	findEslintConfig,
 	getAgentsFileUpdate,
 	install,
+	runCli,
 	updateEslintConfig,
 } from "../cli";
 
@@ -31,19 +31,68 @@ const eslintConfig = defineConfig([
 export default eslintConfig;
 `;
 
-function createWritableBuffer() {
-	let output = "";
+type MockUi = {
+	confirmCalls: number;
+	errors: string[];
+	outros: string[];
+	cancels: string[];
+	ui: {
+		intro(message: string): void;
+		outro(message: string): void;
+		info(message: string): void;
+		warn(message: string): void;
+		error(message: string): void;
+		cancel(message: string): void;
+		progress(message: string): void;
+		confirm(message: string): Promise<boolean | "cancel">;
+	};
+};
+
+function createMockUi(confirmAnswers: Array<boolean | "cancel"> = []): MockUi {
+	let confirmCalls = 0;
+	const errors: string[] = [];
+	const outros: string[] = [];
+	const cancels: string[] = [];
+
 	return {
-		stream: new Writable({
-			write(chunk, _encoding, callback) {
-				output += chunk.toString();
-				callback();
+		get confirmCalls() {
+			return confirmCalls;
+		},
+		errors,
+		outros,
+		cancels,
+		ui: {
+			intro() {},
+			outro(message: string) {
+				outros.push(message);
 			},
-		}),
-		get output() {
-			return output;
+			info() {},
+			warn() {},
+			error(message: string) {
+				errors.push(message);
+			},
+			cancel(message: string) {
+				cancels.push(message);
+			},
+			progress() {},
+			async confirm() {
+				confirmCalls += 1;
+				const next = confirmAnswers.shift();
+				return next ?? false;
+			},
 		},
 	};
+}
+
+function stripAnsi(value: string | undefined): string {
+	return value?.replace(/\x1b\[[0-9;?]*[A-Za-z]/g, "") ?? "";
+}
+
+async function setupInstallFixture() {
+	const cwd = await mkdtemp(join(tmpdir(), "raula-cli-"));
+	await writeFile(join(cwd, "eslint.config.mjs"), createNextConfig);
+	await writeFile(join(cwd, "AGENTS.md"), "# Local instructions\n");
+	return { cwd };
 }
 
 describe("eslint-plugin-raula CLI", () => {
@@ -78,6 +127,14 @@ export default eslintConfig;
 		expect(updateEslintConfig(updated)).toBe(updated);
 	});
 
+	test("preserves 2-space indentation for create-next style config", () => {
+		const updated = updateEslintConfig(createNextConfig);
+
+		expect(updated).toContain(
+			"  ...raulaTailwind,\n  ...raulaNextLayout,\n  ...nextVitals,",
+		);
+	});
+
 	test("adds Raula presets to export default array flat config", () => {
 		const source = `export default [
 \t{
@@ -95,6 +152,86 @@ export default eslintConfig;
 			'import raulaNextLayout from "eslint-plugin-raula/next-layout";',
 		);
 		expect(updated).toContain("\t...raulaTailwind,\n\t...raulaNextLayout,");
+	});
+
+	test("uses tab indentation for tab-indented config arrays", () => {
+		const source = `import { defineConfig } from "eslint/config";
+
+const eslintConfig = defineConfig([
+\t{
+\t\trules: {},
+\t},
+]);
+
+export default eslintConfig;
+`;
+
+		const updated = updateEslintConfig(source);
+
+		expect(updated).toContain(
+			"\t...raulaTailwind,\n\t...raulaNextLayout,\n\t{",
+		);
+	});
+
+	test("uses 4-space indentation for 4-space-indented config arrays", () => {
+		const source = `import { defineConfig } from "eslint/config";
+
+const eslintConfig = defineConfig([
+    {
+        rules: {},
+    },
+]);
+
+export default eslintConfig;
+`;
+
+		const updated = updateEslintConfig(source);
+
+		expect(updated).toContain(
+			"    ...raulaTailwind,\n    ...raulaNextLayout,\n    {",
+		);
+	});
+
+	test("uses detected file indentation for empty defineConfig array", () => {
+		const source = `import { defineConfig } from "eslint/config";
+
+function noop() {
+    return true;
+}
+
+export default defineConfig([]);
+`;
+
+		const updated = updateEslintConfig(source);
+
+		expect(updated).toContain("defineConfig([\n    ...raulaTailwind,");
+		expect(updated).toContain("    ...raulaNextLayout,");
+	});
+
+	test("falls back to 2 spaces when indentation cannot be detected", () => {
+		const source = "export default [];\n";
+
+		const updated = updateEslintConfig(source);
+
+		expect(updated).toContain("export default [\n  ...raulaTailwind,");
+		expect(updated).toContain("  ...raulaNextLayout,");
+	});
+
+	test("empty config array ignores later indented blocks when inferring array item indentation", () => {
+		const source = `const values = [1];
+
+export default defineConfig([]);
+
+if (values.length > 0) {
+        console.log("later 8-space-indented block");
+}
+`;
+
+		const updated = updateEslintConfig(source);
+
+		expect(updated).toContain("defineConfig([\n    ...raulaTailwind,");
+		expect(updated).toContain("    ...raulaNextLayout,");
+		expect(updated).not.toContain("defineConfig([\n        ...raulaTailwind,");
 	});
 
 	test("throws for unsupported config shapes", () => {
@@ -123,12 +260,12 @@ export default eslintConfig;
 			[
 				"# Local instructions",
 				"",
-				"<!-- eslint-plugin-raula-instruct-start -->",
-				"<!-- Managed by `eslint-plugin-raula instruct` -->",
+				"<!-- eslint-plugin-raula-start -->",
+				"<!-- Managed by `eslint-plugin-raula install` -->",
 				"Before editing files that touch styling, JSX className usage, global CSS selectors, or Next.js layout files, read:",
 				"`./node_modules/eslint-plugin-raula/REFERENCE.md`",
 				"This block is supplemental and should complement, not override, local project instructions.",
-				"<!-- eslint-plugin-raula-instruct-end -->",
+				"<!-- eslint-plugin-raula-end -->",
 				"",
 			].join("\n"),
 		);
@@ -138,33 +275,160 @@ export default eslintConfig;
 		expect(update.next).toBe(update.existing);
 	});
 
-	test("accepts piped yes answers for ESLint config and AGENTS prompts", async () => {
-		const cwd = await mkdtemp(join(tmpdir(), "raula-cli-"));
-		await writeFile(join(cwd, "eslint.config.mjs"), createNextConfig);
-		await writeFile(join(cwd, "AGENTS.md"), "# Local instructions\n");
-		const output = createWritableBuffer();
+	test("--eslint --agents-md updates both targets without prompting", async () => {
+		const { cwd } = await setupInstallFixture();
+		const mock = createMockUi();
 
 		await install(cwd, {
-			input: Readable.from(["y\ny\n"]),
-			output: output.stream,
+			options: { eslint: true, agentsMd: true },
+			ui: mock.ui,
 		});
 
 		const eslintConfig = await readFile(join(cwd, "eslint.config.mjs"), "utf8");
 		const agents = await readFile(join(cwd, "AGENTS.md"), "utf8");
-
 		expect(eslintConfig).toContain(
 			'import raulaTailwind from "eslint-plugin-raula/tailwind";',
 		);
+		expect(agents).toContain("<!-- eslint-plugin-raula-start -->");
+		expect(mock.confirmCalls).toBe(0);
+		expect(stripAnsi(mock.outros.at(-1))).toContain(
+			"Success! Updated ESLint config and AGENTS.md.",
+		);
+	});
+
+	test("--eslint --no-agents-md updates only ESLint config", async () => {
+		const { cwd } = await setupInstallFixture();
+		const mock = createMockUi();
+
+		await install(cwd, {
+			options: { eslint: true, agentsMd: false },
+			ui: mock.ui,
+		});
+
+		const eslintConfig = await readFile(join(cwd, "eslint.config.mjs"), "utf8");
+		const agents = await readFile(join(cwd, "AGENTS.md"), "utf8");
 		expect(eslintConfig).toContain(
-			'import raulaNextLayout from "eslint-plugin-raula/next-layout";',
+			'import raulaTailwind from "eslint-plugin-raula/tailwind";',
 		);
+		expect(agents).toBe("# Local instructions\n");
+		expect(mock.confirmCalls).toBe(0);
+		expect(stripAnsi(mock.outros.at(-1))).toContain(
+			"Success! Updated ESLint config.",
+		);
+	});
+
+	test("--no-eslint --agents-md updates only AGENTS.md", async () => {
+		const { cwd } = await setupInstallFixture();
+		const mock = createMockUi();
+
+		await install(cwd, {
+			options: { eslint: false, agentsMd: true },
+			ui: mock.ui,
+		});
+
+		const eslintConfig = await readFile(join(cwd, "eslint.config.mjs"), "utf8");
+		const agents = await readFile(join(cwd, "AGENTS.md"), "utf8");
+		expect(eslintConfig).not.toContain(
+			'import raulaTailwind from "eslint-plugin-raula/tailwind";',
+		);
+		expect(agents).toContain("<!-- eslint-plugin-raula-start -->");
+		expect(mock.confirmCalls).toBe(0);
+		expect(stripAnsi(mock.outros.at(-1))).toContain(
+			"Success! Updated AGENTS.md.",
+		);
+	});
+
+	test("--no-eslint --no-agents-md applies no changes", async () => {
+		const { cwd } = await setupInstallFixture();
+		const mock = createMockUi();
+
+		await install(cwd, {
+			options: { eslint: false, agentsMd: false },
+			ui: mock.ui,
+		});
+
+		const eslintConfig = await readFile(join(cwd, "eslint.config.mjs"), "utf8");
+		const agents = await readFile(join(cwd, "AGENTS.md"), "utf8");
+		expect(eslintConfig).toBe(createNextConfig);
+		expect(agents).toBe("# Local instructions\n");
+		expect(mock.confirmCalls).toBe(0);
+		expect(mock.outros.at(-1)).toBe("No changes applied.");
+	});
+
+	test("--eslint prompts only AGENTS.md when AGENTS option is unspecified", async () => {
+		const { cwd } = await setupInstallFixture();
+		const mock = createMockUi([false]);
+
+		await install(cwd, {
+			options: { eslint: true, agentsMd: undefined },
+			ui: mock.ui,
+		});
+
+		const eslintConfig = await readFile(join(cwd, "eslint.config.mjs"), "utf8");
+		const agents = await readFile(join(cwd, "AGENTS.md"), "utf8");
 		expect(eslintConfig).toContain(
-			"  ...raulaTailwind,\n  ...raulaNextLayout,\n  ...nextVitals,",
+			'import raulaTailwind from "eslint-plugin-raula/tailwind";',
 		);
-		expect(agents).toContain("<!-- eslint-plugin-raula-instruct-start -->");
-		expect(output.output).toContain("Apply ESLint config changes?");
-		expect(output.output).toContain(
-			"Update AGENTS.md with Raula instructions?",
+		expect(agents).toBe("# Local instructions\n");
+		expect(mock.confirmCalls).toBe(1);
+		expect(stripAnsi(mock.outros.at(-1))).toContain(
+			"Success! Updated ESLint config.",
 		);
+	});
+
+	test("cancel during prompt does not update either file", async () => {
+		const { cwd } = await setupInstallFixture();
+		const mock = createMockUi(["cancel"]);
+
+		await install(cwd, {
+			options: { eslint: undefined, agentsMd: undefined },
+			ui: mock.ui,
+		});
+
+		const eslintConfig = await readFile(join(cwd, "eslint.config.mjs"), "utf8");
+		const agents = await readFile(join(cwd, "AGENTS.md"), "utf8");
+		expect(eslintConfig).toBe(createNextConfig);
+		expect(agents).toBe("# Local instructions\n");
+		expect(mock.confirmCalls).toBe(1);
+		expect(mock.cancels.at(-1)).toBe("Cancelled. No changes applied.");
+		expect(mock.outros.at(-1)).toBe("No changes applied.");
+	});
+
+	test("conflicting options fail and do not update files", async () => {
+		const { cwd } = await setupInstallFixture();
+		const mock = createMockUi();
+		process.exitCode = 0;
+
+		await runCli(
+			["node", "eslint-plugin-raula", "install", "--eslint", "--no-eslint"],
+			cwd,
+			mock.ui,
+		);
+
+		const eslintConfig = await readFile(join(cwd, "eslint.config.mjs"), "utf8");
+		const agents = await readFile(join(cwd, "AGENTS.md"), "utf8");
+		expect(eslintConfig).toBe(createNextConfig);
+		expect(agents).toBe("# Local instructions\n");
+		expect(mock.errors.at(-1)).toContain("Conflicting options");
+		process.exitCode = 0;
+	});
+
+	test("unknown option fails and does not update files", async () => {
+		const { cwd } = await setupInstallFixture();
+		const mock = createMockUi();
+		process.exitCode = 0;
+
+		await runCli(
+			["node", "eslint-plugin-raula", "install", "--wat"],
+			cwd,
+			mock.ui,
+		);
+
+		const eslintConfig = await readFile(join(cwd, "eslint.config.mjs"), "utf8");
+		const agents = await readFile(join(cwd, "AGENTS.md"), "utf8");
+		expect(eslintConfig).toBe(createNextConfig);
+		expect(agents).toBe("# Local instructions\n");
+		expect(mock.errors.at(-1)).toBe("Unknown option: --wat");
+		process.exitCode = 0;
 	});
 });

--- a/packages/eslint-plugin-raula/tsconfig.json
+++ b/packages/eslint-plugin-raula/tsconfig.json
@@ -3,6 +3,7 @@
 		"target": "ES2022",
 		"module": "ESNext",
 		"moduleResolution": "Bundler",
+		"types": ["node"],
 		"strict": true,
 		"declaration": true,
 		"declarationMap": false,

--- a/packages/eslint-plugin-raula/tsup.config.ts
+++ b/packages/eslint-plugin-raula/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-	entry: ["index.ts", "tailwind.ts", "next-layout.ts"],
+	entry: ["index.ts", "tailwind.ts", "next-layout.ts", "cli.ts"],
 	format: ["esm"],
 	dts: true,
 	clean: true,


### PR DESCRIPTION
## Summary

- Add `npx eslint-plugin-raula install` to update a project's ESLint flat config and optional `AGENTS.md` instructions.
- Always add both Raula presets: `eslint-plugin-raula/tailwind` and `eslint-plugin-raula/next-layout`.
- Replace the old `instruct` flow with the installer-managed `AGENTS.md` update.
- Add a lightweight interactive prompt UI without Clack, including arrow-key `Yes / No` selection, cursor hiding, highlighted file names, and a final success message.
- Add non-interactive flags: `--eslint`, `--no-eslint`, `--agents-md`, and `--no-agents-md`.
- Preserve the target ESLint config's indentation style when inserting imports and presets.
- Update README guidance and CLI tests.

## Testing

- `bunx biome check --write packages/eslint-plugin-raula/README.md packages/eslint-plugin-raula/cli.ts packages/eslint-plugin-raula/tests/cli.test.ts`
- `bun test packages/eslint-plugin-raula/tests/cli.test.ts`
- `bun run build --filter eslint-plugin-raula`
- Verified the interactive installer behavior in a local playground project.
