### PR TITLE
release: eslint-plugin-raula v0.0.6

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
     },
     "packages/eslint-plugin-raula": {
       "name": "eslint-plugin-raula",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "bin": {
         "eslint-plugin-raula": "./bin/eslint-plugin-raula.js",
       },

--- a/packages/eslint-plugin-raula/package.json
+++ b/packages/eslint-plugin-raula/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "eslint-plugin-raula",
-	"version": "0.0.5",
+	"version": "0.0.6",
 	"description": "Opinionated ESLint rules and flat-config presets for Tailwind and Next.js app standards.",
 	"keywords": [
 		"eslint",


### PR DESCRIPTION
## Summary
- Bump eslint-plugin-raula to v0.0.6
- Update bun.lock workspace package version

## Validation
- bun run build --filter eslint-plugin-raula
- bun test packages apps
- bun run format:check
- npm --cache /private/tmp/eslint-plugin-raula-npm-cache pack --dry-run