### PR TITLE
Fix npm bin metadata

### DIFF
--- a/packages/eslint-plugin-raula/package.json
+++ b/packages/eslint-plugin-raula/package.json
@@ -23,7 +23,7 @@
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"bin": {
-		"eslint-plugin-raula": "./bin/eslint-plugin-raula.js"
+		"eslint-plugin-raula": "bin/eslint-plugin-raula.js"
 	},
 	"exports": {
 		".": {


### PR DESCRIPTION
## Summary
- normalize the package bin entry so npm does not auto-correct it during publish
- keep the eslint-plugin-raula CLI entrypoint included in the package

## Verification
- npm pack --dry-run --cache /private/tmp/eslint-plugin-raula-npm-cache
- npm publish --dry-run --ignore-scripts --cache /private/tmp/eslint-plugin-raula-npm-cache

Closes #4