### PR TITLE
Allow Tailwind mask-linear arbitrary values

### DIFF
--- a/packages/eslint-plugin-raula/references/exhaustive-tailwind-classes.md
+++ b/packages/eslint-plugin-raula/references/exhaustive-tailwind-classes.md
@@ -46,6 +46,12 @@ Keeping utility usage canonical prevents style drift and makes class names easie
 }
 ```
 
+- Use [Base UI ScrollArea gradient scroll fades](https://base-ui.com/react/components/scroll-area#gradient-scroll-fade) with canonical mask utilities
+
+```tsx
+<div className="mask-linear-[to_bottom,transparent_0,black_min(40px,var(--scroll-area-overflow-y-start)),black_calc(100%_-_min(40px,var(--scroll-area-overflow-y-end,40px))),transparent_100%] mask-no-repeat" />
+```
+
 ## Options
 
 - Configure root pixel value for canonical `rem` conversion.

--- a/packages/eslint-plugin-raula/rules/exhaustive-tailwind-classes.ts
+++ b/packages/eslint-plugin-raula/rules/exhaustive-tailwind-classes.ts
@@ -27,12 +27,20 @@ export const docs = {
 			code: '{\n\trules: {\n\t\t"raula/exhaustive-tailwind-classes": [\n\t\t\t"error",\n\t\t\t{ rootFontSize: 16 },\n\t\t],\n\t},\n}',
 			language: "ts",
 		},
+		{
+			label:
+				"Use [Base UI ScrollArea gradient scroll fades](https://base-ui.com/react/components/scroll-area#gradient-scroll-fade) with canonical mask utilities",
+			code: '<div className="mask-linear-[to_bottom,transparent_0,black_min(40px,var(--scroll-area-overflow-y-start)),black_calc(100%_-_min(40px,var(--scroll-area-overflow-y-end,40px))),transparent_100%] mask-no-repeat" />',
+			language: "tsx",
+		},
 	],
 	options: {
 		description: "Configure root pixel value for canonical `rem` conversion.",
 		schema: "{\n\trootFontSize: 16\n}",
 	},
 } satisfies RuleDoc;
+
+const allowedArbitraryValueUtilities = ["mask-linear"];
 
 export default defineRule({
 	meta: {
@@ -92,6 +100,14 @@ export default defineRule({
 					}
 
 					if (!className.includes("[") && !className.includes("]")) {
+						continue;
+					}
+
+					const isAllowedArbitraryValueClass =
+						allowedArbitraryValueUtilities.some((utility) =>
+							className.startsWith(`${utility}-[`),
+						);
+					if (isAllowedArbitraryValueClass) {
 						continue;
 					}
 

--- a/packages/eslint-plugin-raula/rules/rules.test.ts
+++ b/packages/eslint-plugin-raula/rules/rules.test.ts
@@ -32,10 +32,15 @@ tsxTester.run("exhaustive-tailwind-classes", exhaustiveTailwindClasses, {
 	valid: [
 		'const node = <div className="m-0 md:m-0 text-sm" />;',
 		"const node = <div className={dynamicClassName} />;",
+		'const node = <div className="mask-linear-[to_bottom,transparent_0,black_min(40px,var(--scroll-area-overflow-y-start)),black_calc(100%_-_min(40px,var(--scroll-area-overflow-y-end,40px))),transparent_100%] mask-no-repeat" />;',
 	],
 	invalid: [
 		{
 			code: 'const node = <div className="text-[16px]" />;',
+			errors: [{ messageId: "noArbitraryClass" }],
+		},
+		{
+			code: 'const node = <div className="[mask-image:linear-gradient(transparent,black)]" />;',
 			errors: [{ messageId: "noArbitraryClass" }],
 		},
 	],


### PR DESCRIPTION
## Summary
- Allow canonical Tailwind v4 `mask-linear-[...]` utility arbitrary values in `raula/exhaustive-tailwind-classes`
- Keep broad arbitrary bracket usage such as `text-[16px]` and arbitrary properties like `[mask-image:...]` rejected
- Add a Base UI ScrollArea gradient fade example to the generated rule reference

## Verification
- `bun run build --filter eslint-plugin-raula`
- `bun test packages/eslint-plugin-raula/rules/rules.test.ts`
- `bun run format:check`

Closes #10